### PR TITLE
Refactor navbar links and login icon

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -49,9 +49,12 @@ export default function RootLayout({ children }) {
               { label: 'Home', href: '/' },
               { label: 'Chi Siamo', href: '/chi-siamo' },
               { label: 'Contatti', href: '/contatti' },
+              {
+                label: 'Talk to LEO',
+                href: 'https://chatgpt.com/g/g-68a634b4bb888191b1209375250d95f1-leo?model=gpt-4o',
+                external: true,
+              },
               { label: 'Game', href: '/game' },
-              { label: 'Magazzino', href: '/magazzino' },
-              { label: 'Overview', href: '/overview' },
             ]}
           />
           {children}

--- a/app/styles/navbar.css
+++ b/app/styles/navbar.css
@@ -54,8 +54,12 @@
   transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
-.theme-toggle {
+
+.actions {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .link {
@@ -128,7 +132,7 @@
     transform: translateY(-8px) rotate(-45deg);
   }
 
-  .theme-toggle {
+  .actions {
     margin-left: 0;
   }
 }

--- a/components/Icons.js
+++ b/components/Icons.js
@@ -67,3 +67,43 @@ export function MoonIcon(props) {
     </svg>
   );
 }
+
+export function LogInIcon(props) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      width="1em"
+      height="1em"
+      {...props}
+    >
+      <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+      <polyline points="10 17 15 12 10 7" />
+      <line x1="15" y1="12" x2="3" y2="12" />
+    </svg>
+  );
+}
+
+export function LogOutIcon(props) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      width="1em"
+      height="1em"
+      {...props}
+    >
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <polyline points="16 17 21 12 16 7" />
+      <line x1="21" y1="12" x2="9" y2="12" />
+    </svg>
+  );
+}

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { useSession, signOut } from 'next-auth/react';
 import { useState } from 'react';
 import ThemeToggle from './ThemeToggle';
+import { LogInIcon, LogOutIcon } from './Icons';
 
 export default function Navbar({ items = [] }) {
   const { data: session } = useSession();
@@ -21,23 +22,42 @@ export default function Navbar({ items = [] }) {
         {items.map((item, idx) => (
           <li key={idx} className="item">
             {typeof item === 'object' && !item.type ? (
-              <Link href={item.href} className="link">{item.label}</Link>
+              item.external ? (
+                <a
+                  href={item.href}
+                  className="link"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {item.label}
+                </a>
+              ) : (
+                <Link href={item.href} className="link">
+                  {item.label}
+                </Link>
+              )
             ) : (
               item
             )}
           </li>
         ))}
-        {session ? (
-          <li className="item">
-            <button onClick={() => signOut({ callbackUrl: '/' })} className="link">Logout</button>
-          </li>
-        ) : (
-          <li className="item">
-            <Link href="/login" className="link">Login</Link>
-          </li>
-        )}
       </ul>
-      <ThemeToggle />
+      <div className="actions">
+        {session ? (
+          <button
+            onClick={() => signOut({ callbackUrl: '/' })}
+            className="btn"
+            aria-label="Logout"
+          >
+            <LogOutIcon />
+          </button>
+        ) : (
+          <Link href="/login" className="btn" aria-label="Login">
+            <LogInIcon />
+          </Link>
+        )}
+        <ThemeToggle />
+      </div>
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- simplify navbar link list and add external "Talk to LEO" entry
- convert login/logout into icon button alongside theme toggle
- style navbar actions container for right-aligned icons

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: sh: 1: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68aed1966bf0832fa45acc682ca2c6ed