### PR TITLE
Refine homepage interactions and theme

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,14 +1,15 @@
 import ScrollProgress from "@/components/ScrollProgress";
 import ParallaxAliens from "@/components/ParallaxAliens";
+import WindowEffects from "@/components/WindowEffects";
 
 export default function Home() {
   return (
     <>
       <ScrollProgress />
       <ParallaxAliens />
+      <WindowEffects />
 
       <section id="intro" className="home-section">
-        <img src="/alien1.svg" alt="" className="alien alien-left blue" data-speed="2" />
         <div className="content window">
           <div className="window-bar">
             <span className="window-btn minimize"></span>
@@ -21,11 +22,9 @@ export default function Home() {
             nella realizzazione di prototipi personalizzati.
           </p>
         </div>
-        <img src="/alien2.svg" alt="" className="alien alien-right red" data-speed="2.5" />
       </section>
 
       <section id="chi-siamo" className="home-section">
-        <img src="/alien3.svg" alt="" className="alien alien-left pink" data-speed="2" />
         <div className="content window">
           <div className="window-bar">
             <span className="window-btn minimize"></span>
@@ -37,11 +36,9 @@ export default function Home() {
             Crediamo nell'innovazione e nello stile 8-bit.
           </p>
         </div>
-        <img src="/alien1.svg" alt="" className="alien alien-right blue" data-speed="2.5" />
       </section>
 
       <section id="prodotti" className="home-section">
-        <img src="/alien2.svg" alt="" className="alien alien-left red" data-speed="2" />
         <div className="content window">
           <div className="window-bar">
             <span className="window-btn minimize"></span>
@@ -53,11 +50,9 @@ export default function Home() {
             vita ai tuoi progetti.
           </p>
         </div>
-        <img src="/alien3.svg" alt="" className="alien alien-right pink" data-speed="2.5" />
       </section>
 
       <section id="servizi" className="home-section">
-        <img src="/alien1.svg" alt="" className="alien alien-left blue" data-speed="2" />
         <div className="content window">
           <div className="window-bar">
             <span className="window-btn minimize"></span>
@@ -69,11 +64,9 @@ export default function Home() {
             oltre i confini.
           </p>
         </div>
-        <img src="/alien2.svg" alt="" className="alien alien-right red" data-speed="2.5" />
       </section>
 
       <section id="testimonianze" className="home-section">
-        <img src="/alien3.svg" alt="" className="alien alien-left pink" data-speed="2" />
         <div className="content window">
           <div className="window-bar">
             <span className="window-btn minimize"></span>
@@ -82,11 +75,9 @@ export default function Home() {
           <h2 className="title">Cosa Dicono di Noi</h2>
           <p className="description">"Incredibile esperienza, consigliatissimi!"</p>
         </div>
-        <img src="/alien1.svg" alt="" className="alien alien-right blue" data-speed="2.5" />
       </section>
 
       <section id="contatti" className="home-section">
-        <img src="/alien2.svg" alt="" className="alien alien-left red" data-speed="2" />
         <div className="content window">
           <div className="window-bar">
             <span className="window-btn minimize"></span>
@@ -105,7 +96,6 @@ export default function Home() {
             <button type="submit">Invia</button>
           </form>
         </div>
-        <img src="/alien3.svg" alt="" className="alien alien-right pink" data-speed="2.5" />
       </section>
 
       <div className="space-ship-container">

--- a/app/styles/home.css
+++ b/app/styles/home.css
@@ -7,16 +7,16 @@
   text-align: center;
   color: var(--foreground);
   font-family: var(--font-press-start);
-  background-color: var(--color-black);
+  background-color: var(--background);
 }
 
 .home-section .content {
   position: relative;
-  background: rgba(0, 0, 0, 0.6);
-  padding: 3rem 2rem;
+  background: var(--background);
+  padding: 4rem 3rem;
   margin: 0 2rem;
-  width: 80%;
-  max-width: 600px;
+  width: 90%;
+  max-width: 700px;
   border: 4px solid var(--color-primary);
   box-shadow: 4px 4px 0 var(--color-primary);
   transition: transform 0.3s ease;
@@ -28,11 +28,11 @@
 
 .window-bar {
   position: absolute;
-  top: -2rem;
+  top: -2.5rem;
   left: 0;
   width: 100%;
-  height: 1.5rem;
-  background: var(--color-black);
+  height: 2rem;
+  background: var(--background);
   border: 4px solid var(--color-primary);
   border-bottom: none;
   display: none;
@@ -47,14 +47,14 @@
 }
 
 .window-btn {
-  width: 1rem;
-  height: 1rem;
+  width: 1.5rem;
+  height: 1.5rem;
   display: flex;
   align-items: center;
   justify-content: center;
   font-family: var(--font-press-start);
-  font-size: 0.6rem;
-  line-height: 1rem;
+  font-size: 0.8rem;
+  line-height: 1.5rem;
   border: 2px solid var(--color-white);
   background: var(--color-white);
   color: var(--color-black);
@@ -143,7 +143,7 @@
   width: 20px;
   height: 80vh;
   border: 4px solid var(--color-primary);
-  background: var(--color-black);
+  background: var(--background);
   box-shadow: 4px 4px 0 var(--color-primary);
   z-index: 1000;
 }
@@ -162,17 +162,30 @@
 
 .home-section form input,
 .home-section form textarea {
-  padding: 0.5rem;
+  padding: 0.75rem;
   background: var(--background);
   color: var(--foreground);
   border: 2px solid var(--color-primary);
+  font-size: 1rem;
 }
 
 .home-section form button {
-  padding: 0.5rem;
+  padding: 0.75rem;
   background: var(--color-primary);
   color: var(--color-black);
   border: 2px solid var(--color-primary);
   cursor: pointer;
   font-family: var(--font-press-start);
+  font-size: 1rem;
+}
+
+.content.destroy {
+  animation: explode 0.5s forwards;
+}
+
+@keyframes explode {
+  to {
+    opacity: 0;
+    transform: scale(0.5) rotate(20deg);
+  }
 }

--- a/app/styles/navbar.css
+++ b/app/styles/navbar.css
@@ -75,6 +75,7 @@
 
 .actions .btn:hover {
   transform: scale(1.1);
+  color: var(--color-black);
 }
 
 .link {

--- a/components/ParallaxAliens.js
+++ b/components/ParallaxAliens.js
@@ -3,23 +3,11 @@ import { useEffect } from "react";
 
 export default function ParallaxAliens() {
   useEffect(() => {
-    const aliens = Array.from(document.querySelectorAll('.alien'));
-    aliens.forEach(el => {
-      el.dataset.base = (-el.offsetHeight / 2).toString();
-    });
-
     const handleScroll = () => {
-      const scrollY = window.scrollY;
-      aliens.forEach(el => {
-        const base = parseFloat(el.dataset.base || '0');
-        const speed = parseFloat(el.dataset.speed || '1.5');
-        el.style.transform = `translateY(${scrollY * speed + base}px)`;
-      });
-
       const ship = document.querySelector('.bottom-ship');
       if (ship) {
         const total = document.body.scrollHeight - window.innerHeight;
-        const progress = scrollY / total;
+        const progress = window.scrollY / total;
         const maxX = window.innerWidth - ship.clientWidth;
         ship.style.transform = `translateX(${progress * maxX}px)`;
       }

--- a/components/WindowEffects.js
+++ b/components/WindowEffects.js
@@ -1,0 +1,36 @@
+"use client";
+import { useEffect } from "react";
+
+export default function WindowEffects() {
+  useEffect(() => {
+    const windows = Array.from(document.querySelectorAll('.home-section .content'));
+
+    windows.forEach(win => {
+      const bar = win.querySelector('.window-bar');
+      const closeBtn = bar?.querySelector('.close');
+      const minBtn = bar?.querySelector('.minimize');
+
+      const showBar = () => {
+        bar.style.display = 'flex';
+      };
+
+      const reset = () => {
+        bar.style.display = 'none';
+        win.classList.remove('destroy');
+      };
+
+      win.addEventListener('mouseenter', showBar);
+
+      closeBtn?.addEventListener('click', () => {
+        win.classList.add('destroy');
+        setTimeout(reset, 500);
+      });
+      minBtn?.addEventListener('click', () => {
+        win.classList.add('destroy');
+        setTimeout(reset, 500);
+      });
+    });
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Drop placeholder alien images and add persistent window controls with a simple destruction animation
- Adjust homepage styling for light theme, enlarging content, buttons, and inputs
- Ensure navbar action icons turn black on hover and keep spaceship scroll effect

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden for bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_68af052338f4832faa4870952dddb41e