### PR TITLE
feat: animate homepage space elements

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -99,7 +99,18 @@ export default function Home() {
       </section>
 
       <div className="space-ship-container">
-        <img src="/ship.svg" alt="" className="bottom-ship pink" />
+        <img src="/ship.svg" alt="" className="bottom-ship ship-fluo" />
+        <div className="bullet-container">
+          <span className="bullet" />
+          <span className="bullet" />
+          <span className="bullet" />
+        </div>
+      </div>
+
+      <div className="aliens-layer">
+        <img src="/alien1.svg" alt="" className="alien pink" />
+        <img src="/alien2.svg" alt="" className="alien red" />
+        <img src="/alien3.svg" alt="" className="alien blue" />
       </div>
     </>
   );

--- a/app/styles/home.css
+++ b/app/styles/home.css
@@ -12,6 +12,7 @@
 
 .home-section .content {
   position: relative;
+  z-index: 2;
   background: var(--background);
   padding: 4rem 3rem;
   margin: 0 2rem;
@@ -107,9 +108,13 @@
 }
 
 .space-ship-container {
-  position: relative;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
   height: 80px;
-  margin-bottom: 4rem;
+  pointer-events: none;
+  z-index: 1;
 }
 
 .bottom-ship {
@@ -118,6 +123,67 @@
   left: 0;
   width: 60px;
   height: 60px;
+}
+
+.ship-fluo {
+  color: #ff00ff;
+  filter: drop-shadow(0 0 10px #ff00ff);
+}
+
+.bullet-container {
+  position: absolute;
+  bottom: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.bullet {
+  position: absolute;
+  bottom: 0;
+  width: 4px;
+  height: 20px;
+  background: var(--color-primary);
+}
+
+.bullet:nth-child(1) {
+  left: -15px;
+}
+
+.bullet:nth-child(2) {
+  left: 0;
+}
+
+.bullet:nth-child(3) {
+  left: 15px;
+}
+
+.aliens-layer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.alien {
+  position: absolute;
+  top: -80px;
+  width: 80px;
+  height: 80px;
+}
+
+.aliens-layer .alien:nth-child(1) {
+  left: 10%;
+}
+
+.aliens-layer .alien:nth-child(2) {
+  left: 45%;
+}
+
+.aliens-layer .alien:nth-child(3) {
+  left: 80%;
 }
 
 @media (max-width: 600px) {
@@ -131,6 +197,9 @@
   .bottom-ship {
     width: 40px;
     height: 40px;
+  }
+  .progress-container {
+    display: none;
   }
 }
 

--- a/components/ParallaxAliens.js
+++ b/components/ParallaxAliens.js
@@ -4,13 +4,26 @@ import { useEffect } from "react";
 export default function ParallaxAliens() {
   useEffect(() => {
     const handleScroll = () => {
+      const total = document.body.scrollHeight - window.innerHeight;
+      const progress = window.scrollY / total;
+
       const ship = document.querySelector('.bottom-ship');
       if (ship) {
-        const total = document.body.scrollHeight - window.innerHeight;
-        const progress = window.scrollY / total;
         const maxX = window.innerWidth - ship.clientWidth;
         ship.style.transform = `translateX(${progress * maxX}px)`;
       }
+
+      const bullets = document.querySelectorAll('.bullet');
+      bullets.forEach((bullet, i) => {
+        bullet.style.transform = `translateY(${-(window.scrollY * 0.5 + i * 80)}px)`;
+      });
+
+      const aliens = document.querySelectorAll('.alien');
+      aliens.forEach((alien, i) => {
+        const y = window.scrollY * (0.3 + i * 0.1);
+        const x = Math.sin(window.scrollY / 80 + i) * 50;
+        alien.style.transform = `translate(${x}px, ${y}px)`;
+      });
     };
 
     window.addEventListener('scroll', handleScroll);


### PR DESCRIPTION
## Summary
- add fixed fluorescent ship with scroll-driven bullets and alien icons
- move aliens and bullets via ParallaxAliens effect
- hide side progress bar on mobile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden for bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_68af0a8e074c832fa34b4e14a5330dc6