### PR TITLE
Improve home game visuals and content

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -49,13 +49,13 @@ export default function RootLayout({ children }) {
             items={[
               { label: 'Home', href: '/' },
               { label: 'Chi Siamo', href: '/chi-siamo' },
-              { label: 'Contatti', href: '/contatti' },
+              { label: 'Game', href: '/game' },
               {
                 label: 'Talk to LEO',
                 href: 'http://evolve3d.it/leo/virtual-assistant.html',
                 external: true,
               },
-              { label: 'Game', href: '/game' },
+              { label: 'Contatti', href: '/contatti' },
             ]}
           />
           {children}

--- a/app/page.js
+++ b/app/page.js
@@ -15,9 +15,13 @@ export default function Home() {
           </div>
           <h2 className="title">Benvenuto in Evolve</h2>
           <p className="description">
-            Evolve è una società di consulenza informatica e stampa 3D. Offriamo
-            supporto nello sviluppo software, nella gestione di infrastrutture e
-            nella realizzazione di prototipi personalizzati.
+            Evolve è la tua officina digitale: realizziamo software su misura e
+            prototipi in stampa 3D con dispositivi PLA dotati di NFC. Con
+            soluzioni come E-Linker ed E-Talk aiutiamo persone e oggetti a
+            comunicare, offrendo a ogni impresa l'accesso all'innovazione. Offriamo
+            consulenza e strumenti integrati per ottimizzare e innovare i processi
+            aziendali delle piccole e medie imprese: anche tu ora te lo puoi
+            permettere!
           </p>
         </div>
       </section>
@@ -30,8 +34,9 @@ export default function Home() {
           </div>
           <h2 className="title">Chi Siamo</h2>
           <p className="description">
-            Siamo un team di appassionati di tecnologia con un tocco retro.
-            Crediamo nell'innovazione e nello stile 8-bit.
+            Siamo un team di professionisti appassionati di tecnologia e cultura
+            8-bit. Uniamo esperienza in sviluppo, IoT e design per accompagnarti
+            con cordialità verso il futuro digitale.
           </p>
         </div>
       </section>
@@ -44,8 +49,9 @@ export default function Home() {
           </div>
           <h2 className="title">I Nostri Prodotti</h2>
           <p className="description">
-            Dalla stampa 3D agli strumenti software, offriamo prodotti per dare
-            vita ai tuoi progetti.
+            Dal nostro E-Linker all'E-Talk, sviluppiamo dispositivi e piattaforme
+            che integrano NFC e stampa 3D per connettere ciò che conta. Ogni
+            prodotto è pensato per essere semplice, fluo e pronto all'uso.
           </p>
         </div>
       </section>
@@ -58,8 +64,9 @@ export default function Home() {
           </div>
           <h2 className="title">I Nostri Servizi</h2>
           <p className="description">
-            Consulenza, sviluppo e supporto tecnico per spingere la tua azienda
-            oltre i confini.
+            Offriamo soluzioni integrate e consulenza personalizzata per
+            ottimizzare i processi aziendali. Dallo sviluppo software alla
+            prototipazione rapida, ti guidiamo nell'innovazione della tua PMI.
           </p>
         </div>
       </section>
@@ -71,7 +78,11 @@ export default function Home() {
             <span className="window-btn close"></span>
           </div>
           <h2 className="title">Cosa Dicono di Noi</h2>
-          <p className="description">"Incredibile esperienza, consigliatissimi!"</p>
+          <p className="description">
+            "I ragazzi di Evolve hanno trasformato le nostre idee in realtà in
+            pochissimo tempo!"<br />"Finalmente un partner che parla la lingua
+            delle piccole imprese."
+          </p>
         </div>
       </section>
 

--- a/app/styles/home.css
+++ b/app/styles/home.css
@@ -79,21 +79,6 @@
   transform: translateY(-2px);
 }
 
-.alien {
-  position: absolute;
-  top: 50%;
-  width: 40px;
-  height: 40px;
-  z-index: 1;
-}
-
-.alien-left {
-  left: 5%;
-}
-
-.alien-right {
-  right: 5%;
-}
 
 .blue {
   color: #0ff;
@@ -143,10 +128,14 @@
   filter: drop-shadow(0 0 10px #ff0000);
 }
 
-.bullet-container {
-  position: absolute;
+.bullet-layer {
+  position: fixed;
   bottom: 60px;
   left: 0;
+  width: 100%;
+  height: calc(100% - 60px);
+  pointer-events: none;
+  z-index: 1;
 }
 
 .bullet {
@@ -156,18 +145,6 @@
   height: 20px;
   background: #ff0000;
   box-shadow: 0 0 10px #ff0000;
-}
-
-.bullet:nth-child(1) {
-  left: -15px;
-}
-
-.bullet:nth-child(2) {
-  left: 0;
-}
-
-.bullet:nth-child(3) {
-  left: 15px;
 }
 
 .aliens-layer {
@@ -180,31 +157,11 @@
   z-index: 0;
 }
 
-.alien {
+.aliens-layer .alien {
   position: absolute;
   top: -80px;
   width: 80px;
   height: 80px;
-}
-
-.aliens-layer .alien:nth-child(1) {
-  left: 10%;
-}
-
-.aliens-layer .alien:nth-child(2) {
-  left: 30%;
-}
-
-.aliens-layer .alien:nth-child(3) {
-  left: 50%;
-}
-
-.aliens-layer .alien:nth-child(4) {
-  left: 70%;
-}
-
-.aliens-layer .alien:nth-child(5) {
-  left: 90%;
 }
 
 @media (max-width: 600px) {
@@ -212,7 +169,7 @@
     width: 90%;
     padding: 2rem 1rem;
   }
-  .alien {
+  .aliens-layer .alien {
     display: none;
   }
   .bottom-ship {
@@ -273,9 +230,22 @@
   animation: explode 0.5s forwards;
 }
 
+.content.fade-in {
+  animation: fadeIn 1s forwards;
+}
+
 @keyframes explode {
   to {
     opacity: 0;
     transform: scale(0.5) rotate(20deg);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
   }
 }

--- a/components/HomeParallax.js
+++ b/components/HomeParallax.js
@@ -10,19 +10,9 @@ export default function HomeParallax() {
       <ParallaxAliens />
       <div className="space-ship-container">
         <img src="/ship.svg" alt="" className="bottom-ship ship-fluo" />
-        <div className="bullet-container">
-          <span className="bullet" />
-          <span className="bullet" />
-          <span className="bullet" />
-        </div>
       </div>
-      <div className="aliens-layer">
-        <img src="/alien1.svg" alt="" className="alien pink" />
-        <img src="/alien2.svg" alt="" className="alien red" />
-        <img src="/alien3.svg" alt="" className="alien blue" />
-        <img src="/alien1.svg" alt="" className="alien green" />
-        <img src="/alien2.svg" alt="" className="alien yellow" />
-      </div>
+      <div className="bullet-layer"></div>
+      <div className="aliens-layer"></div>
     </>
   );
 }

--- a/components/ParallaxAliens.js
+++ b/components/ParallaxAliens.js
@@ -3,38 +3,92 @@ import { useEffect } from "react";
 
 export default function ParallaxAliens() {
   useEffect(() => {
-    const handleScroll = () => {
-      const ship = document.querySelector('.bottom-ship');
-      const bulletContainer = document.querySelector('.bullet-container');
-      if (ship && bulletContainer) {
-        const maxX = window.innerWidth - ship.clientWidth;
-        const center = maxX / 2;
-        const shipX = center + Math.sin(window.scrollY / 50) * center;
-        const shipStep = Math.round(shipX / 20) * 20;
-        ship.style.transform = `translateX(${shipStep}px)`;
-        bulletContainer.style.transform = `translateX(${shipStep + ship.clientWidth / 2}px)`;
+    const ship = document.querySelector(".bottom-ship");
+    const bulletLayer = document.querySelector(".bullet-layer");
+    const alienLayer = document.querySelector(".aliens-layer");
+    const colors = ["pink", "red", "blue", "green", "yellow"];
+    const bullets = [];
+    const aliens = [];
+
+    const handleMouseMove = (e) => {
+      if (ship) {
+        ship.style.left = `${e.clientX - ship.clientWidth / 2}px`;
       }
-
-      const bullets = document.querySelectorAll('.bullet');
-      bullets.forEach((bullet, i) => {
-        const y = window.scrollY * 0.5 + i * 80;
-        const yStep = Math.round(y / 20) * 20;
-        bullet.style.transform = `translateY(-${yStep}px)`;
-      });
-
-      const aliens = document.querySelectorAll('.alien');
-      aliens.forEach((alien, i) => {
-        const y = window.scrollY * (0.3 + i * 0.1);
-        const x = Math.sin(window.scrollY / 80 + i) * 50;
-        const stepX = Math.round(x / 20) * 20;
-        const stepY = Math.round(y / 20) * 20;
-        alien.style.transform = `translate(${stepX}px, ${stepY}px)`;
-      });
     };
 
-    window.addEventListener('scroll', handleScroll);
-    handleScroll();
-    return () => window.removeEventListener('scroll', handleScroll);
+    window.addEventListener("mousemove", handleMouseMove);
+
+    const spawnBullet = () => {
+      if (!ship || !bulletLayer) return;
+      const bullet = document.createElement("span");
+      bullet.className = "bullet";
+      bullet.style.left = `${ship.offsetLeft + ship.clientWidth / 2 - 2}px`;
+      bullet.style.bottom = `0px`;
+      bulletLayer.appendChild(bullet);
+      bullets.push(bullet);
+    };
+
+    const spawnAlien = () => {
+      if (!alienLayer) return;
+      const alien = document.createElement("img");
+      const idx = Math.floor(Math.random() * 3) + 1;
+      alien.src = `/alien${idx}.svg`;
+      const color = colors[Math.floor(Math.random() * colors.length)];
+      alien.className = `alien ${color}`;
+      alien.style.left = `${Math.random() * (window.innerWidth - 80)}px`;
+      alien.style.top = `-80px`;
+      alienLayer.appendChild(alien);
+      aliens.push(alien);
+    };
+
+    const update = () => {
+      bullets.forEach((b, i) => {
+        b.style.bottom = `${parseFloat(b.style.bottom) + 5}px`;
+        if (parseFloat(b.style.bottom) > window.innerHeight) {
+          b.remove();
+          bullets.splice(i, 1);
+        }
+      });
+
+      aliens.forEach((a, i) => {
+        a.style.top = `${parseFloat(a.style.top) + 2}px`;
+        if (parseFloat(a.style.top) > window.innerHeight) {
+          a.remove();
+          aliens.splice(i, 1);
+        }
+      });
+
+      bullets.forEach((b, bi) => {
+        const bRect = b.getBoundingClientRect();
+        aliens.forEach((a, ai) => {
+          const aRect = a.getBoundingClientRect();
+          if (
+            bRect.left < aRect.right &&
+            bRect.right > aRect.left &&
+            bRect.top < aRect.bottom &&
+            bRect.bottom > aRect.top
+          ) {
+            a.remove();
+            aliens.splice(ai, 1);
+            b.remove();
+            bullets.splice(bi, 1);
+          }
+        });
+      });
+
+      requestAnimationFrame(update);
+    };
+
+    update();
+
+    const bulletInterval = setInterval(spawnBullet, 300);
+    const alienInterval = setInterval(spawnAlien, 1000);
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      clearInterval(bulletInterval);
+      clearInterval(alienInterval);
+    };
   }, []);
 
   return null;

--- a/components/WindowEffects.js
+++ b/components/WindowEffects.js
@@ -17,18 +17,23 @@ export default function WindowEffects() {
       const reset = () => {
         bar.style.display = 'none';
         win.classList.remove('destroy');
+        win.style.visibility = 'hidden';
+        setTimeout(() => {
+          win.style.visibility = 'visible';
+          win.classList.add('fade-in');
+          setTimeout(() => win.classList.remove('fade-in'), 1000);
+        }, 2000);
       };
 
       win.addEventListener('mouseenter', showBar);
 
-      closeBtn?.addEventListener('click', () => {
+      const destroyWindow = () => {
         win.classList.add('destroy');
         setTimeout(reset, 500);
-      });
-      minBtn?.addEventListener('click', () => {
-        win.classList.add('destroy');
-        setTimeout(reset, 500);
-      });
+      };
+
+      closeBtn?.addEventListener('click', destroyWindow);
+      minBtn?.addEventListener('click', destroyWindow);
     });
   }, []);
 

--- a/public/alien1.svg
+++ b/public/alien1.svg
@@ -1,6 +1,3 @@
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <circle cx="12" cy="12" r="8" fill="currentColor"/>
-  <circle cx="9" cy="10" r="1.5" fill="#000"/>
-  <circle cx="15" cy="10" r="1.5" fill="#000"/>
-  <path d="M8 16c2 1.5 6 1.5 8 0" stroke="#000" stroke-width="2" fill="none"/>
 </svg>

--- a/public/alien2.svg
+++ b/public/alien2.svg
@@ -1,6 +1,3 @@
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <rect x="4" y="4" width="16" height="16" rx="3" fill="currentColor"/>
-  <circle cx="9" cy="10" r="1.5" fill="#000"/>
-  <circle cx="15" cy="10" r="1.5" fill="#000"/>
-  <path d="M8 16h8" stroke="#000" stroke-width="2"/>
 </svg>

--- a/public/alien3.svg
+++ b/public/alien3.svg
@@ -1,5 +1,3 @@
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <path d="M12 2L20 8v8l-8 6-8-6V8z" fill="currentColor"/>
-  <circle cx="9" cy="12" r="1.2" fill="#000"/>
-  <circle cx="15" cy="12" r="1.2" fill="#000"/>
 </svg>


### PR DESCRIPTION
## Summary
- Fill alien SVGs with solid neon colors
- Rework home mini-game with straight-shooting bullets, enemy collisions, and more foes
- Expand home section copy and reorder navbar items
- Add delayed ghostly return when closing info windows

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden when fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68af1130afec832f9f93ddf2839474e4