### PR TITLE
Enhance home page window controls and parallax

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,5 +1,6 @@
 import ScrollProgress from "@/components/ScrollProgress";
 import WindowEffects from "@/components/WindowEffects";
+import Link from "next/link";
 
 export default function Home() {
   return (
@@ -10,8 +11,24 @@ export default function Home() {
       <section id="intro" className="home-section">
         <div className="content window">
           <div className="window-bar">
-            <span className="window-btn minimize"></span>
-            <span className="window-btn close"></span>
+            <span
+              className="window-btn minimize"
+              title="Riduci"
+              aria-label="Riduci"
+            ></span>
+            <Link
+              href="/chi-siamo"
+              className="window-btn maximize"
+              title="Ingrandisci"
+              aria-label="Ingrandisci"
+            >
+              {" "}
+            </Link>
+            <span
+              className="window-btn close"
+              title="Chiudi"
+              aria-label="Chiudi"
+            ></span>
           </div>
           <h2 className="title">Benvenuto in Evolve</h2>
           <p className="description">
@@ -29,8 +46,24 @@ export default function Home() {
       <section id="chi-siamo" className="home-section">
         <div className="content window">
           <div className="window-bar">
-            <span className="window-btn minimize"></span>
-            <span className="window-btn close"></span>
+            <span
+              className="window-btn minimize"
+              title="Riduci"
+              aria-label="Riduci"
+            ></span>
+            <Link
+              href="/chi-siamo"
+              className="window-btn maximize"
+              title="Ingrandisci"
+              aria-label="Ingrandisci"
+            >
+              {" "}
+            </Link>
+            <span
+              className="window-btn close"
+              title="Chiudi"
+              aria-label="Chiudi"
+            ></span>
           </div>
           <h2 className="title">Chi Siamo</h2>
           <p className="description">
@@ -44,8 +77,24 @@ export default function Home() {
       <section id="prodotti" className="home-section">
         <div className="content window">
           <div className="window-bar">
-            <span className="window-btn minimize"></span>
-            <span className="window-btn close"></span>
+            <span
+              className="window-btn minimize"
+              title="Riduci"
+              aria-label="Riduci"
+            ></span>
+            <Link
+              href="/chi-siamo"
+              className="window-btn maximize"
+              title="Ingrandisci"
+              aria-label="Ingrandisci"
+            >
+              {" "}
+            </Link>
+            <span
+              className="window-btn close"
+              title="Chiudi"
+              aria-label="Chiudi"
+            ></span>
           </div>
           <h2 className="title">I Nostri Prodotti</h2>
           <p className="description">
@@ -59,8 +108,24 @@ export default function Home() {
       <section id="servizi" className="home-section">
         <div className="content window">
           <div className="window-bar">
-            <span className="window-btn minimize"></span>
-            <span className="window-btn close"></span>
+            <span
+              className="window-btn minimize"
+              title="Riduci"
+              aria-label="Riduci"
+            ></span>
+            <Link
+              href="/chi-siamo"
+              className="window-btn maximize"
+              title="Ingrandisci"
+              aria-label="Ingrandisci"
+            >
+              {" "}
+            </Link>
+            <span
+              className="window-btn close"
+              title="Chiudi"
+              aria-label="Chiudi"
+            ></span>
           </div>
           <h2 className="title">I Nostri Servizi</h2>
           <p className="description">
@@ -74,8 +139,24 @@ export default function Home() {
       <section id="testimonianze" className="home-section">
         <div className="content window">
           <div className="window-bar">
-            <span className="window-btn minimize"></span>
-            <span className="window-btn close"></span>
+            <span
+              className="window-btn minimize"
+              title="Riduci"
+              aria-label="Riduci"
+            ></span>
+            <Link
+              href="/chi-siamo"
+              className="window-btn maximize"
+              title="Ingrandisci"
+              aria-label="Ingrandisci"
+            >
+              {" "}
+            </Link>
+            <span
+              className="window-btn close"
+              title="Chiudi"
+              aria-label="Chiudi"
+            ></span>
           </div>
           <h2 className="title">Cosa Dicono di Noi</h2>
           <p className="description">
@@ -89,8 +170,24 @@ export default function Home() {
       <section id="contatti" className="home-section">
         <div className="content window">
           <div className="window-bar">
-            <span className="window-btn minimize"></span>
-            <span className="window-btn close"></span>
+            <span
+              className="window-btn minimize"
+              title="Riduci"
+              aria-label="Riduci"
+            ></span>
+            <Link
+              href="/chi-siamo"
+              className="window-btn maximize"
+              title="Ingrandisci"
+              aria-label="Ingrandisci"
+            >
+              {" "}
+            </Link>
+            <span
+              className="window-btn close"
+              title="Chiudi"
+              aria-label="Chiudi"
+            ></span>
           </div>
           <h2 className="title">Contattaci</h2>
           <form

--- a/app/styles/footer.css
+++ b/app/styles/footer.css
@@ -7,6 +7,7 @@
   padding: 2rem 0;
   background: var(--color-black);
   color: var(--color-white);
+  z-index: 2;
 }
 
 .footer::before {

--- a/app/styles/home.css
+++ b/app/styles/home.css
@@ -61,6 +61,10 @@
   color: var(--color-black);
 }
 
+.window-btn.maximize {
+  background: #00ff00;
+}
+
 .window-btn.close {
   background: #ff0000;
 }
@@ -79,31 +83,12 @@
   transform: translateY(-2px);
 }
 
-
-.blue {
-  color: #0ff;
-  filter: drop-shadow(0 0 10px #0ff);
+.window-btn.maximize::before {
+  content: "\25A1";
+  transform: translateY(-1px);
 }
 
-.red {
-  color: #ff0000;
-  filter: drop-shadow(0 0 10px #ff0000);
-}
 
-.pink {
-  color: #ff00ff;
-  filter: drop-shadow(0 0 10px #ff00ff);
-}
-
-.green {
-  color: #39FF14;
-  filter: drop-shadow(0 0 10px #39FF14);
-}
-
-.yellow {
-  color: #ffff00;
-  filter: drop-shadow(0 0 10px #ffff00);
-}
 
 .space-ship-container {
   position: fixed;
@@ -124,8 +109,8 @@
 }
 
 .ship-fluo {
-  color: #ff0000;
-  filter: drop-shadow(0 0 10px #ff0000);
+  color: var(--foreground);
+  filter: drop-shadow(0 0 10px var(--foreground));
 }
 
 .bullet-layer {
@@ -143,8 +128,8 @@
   bottom: 0;
   width: 4px;
   height: 20px;
-  background: #ff0000;
-  box-shadow: 0 0 10px #ff0000;
+  background: var(--foreground);
+  box-shadow: 0 0 10px var(--foreground);
 }
 
 .aliens-layer {
@@ -162,6 +147,32 @@
   top: -80px;
   width: 80px;
   height: 80px;
+  color: var(--foreground);
+  filter: drop-shadow(0 0 10px var(--foreground));
+}
+
+.icon-tray {
+  position: fixed;
+  bottom: 10px;
+  left: 10px;
+  display: flex;
+  gap: 0.5rem;
+  z-index: 3;
+}
+
+.window-icon {
+  width: 2rem;
+  height: 2rem;
+  background: var(--color-primary);
+  color: var(--color-black);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-press-start);
+  font-size: 0.75rem;
+  cursor: pointer;
+  border: 2px solid var(--color-primary);
+  box-shadow: 2px 2px 0 var(--color-primary);
 }
 
 @media (max-width: 600px) {

--- a/components/ParallaxAliens.js
+++ b/components/ParallaxAliens.js
@@ -6,7 +6,6 @@ export default function ParallaxAliens() {
     const ship = document.querySelector(".bottom-ship");
     const bulletLayer = document.querySelector(".bullet-layer");
     const alienLayer = document.querySelector(".aliens-layer");
-    const colors = ["pink", "red", "blue", "green", "yellow"];
     const bullets = [];
     const aliens = [];
 
@@ -33,8 +32,7 @@ export default function ParallaxAliens() {
       const alien = document.createElement("img");
       const idx = Math.floor(Math.random() * 3) + 1;
       alien.src = `/alien${idx}.svg`;
-      const color = colors[Math.floor(Math.random() * colors.length)];
-      alien.className = `alien ${color}`;
+      alien.className = "alien";
       alien.style.left = `${Math.random() * (window.innerWidth - 80)}px`;
       alien.style.top = `-80px`;
       alienLayer.appendChild(alien);

--- a/components/WindowEffects.js
+++ b/components/WindowEffects.js
@@ -3,37 +3,39 @@ import { useEffect } from "react";
 
 export default function WindowEffects() {
   useEffect(() => {
-    const windows = Array.from(document.querySelectorAll('.home-section .content'));
+    const windows = Array.from(document.querySelectorAll(".home-section .content"));
 
-    windows.forEach(win => {
-      const bar = win.querySelector('.window-bar');
-      const closeBtn = bar?.querySelector('.close');
-      const minBtn = bar?.querySelector('.minimize');
+    let tray = document.querySelector(".icon-tray");
+    if (!tray) {
+      tray = document.createElement("div");
+      tray.className = "icon-tray";
+      document.body.appendChild(tray);
+    }
 
-      const showBar = () => {
-        bar.style.display = 'flex';
-      };
+    windows.forEach((win) => {
+      const closeBtn = win.querySelector(".close");
+      const minBtn = win.querySelector(".minimize");
 
-      const reset = () => {
-        bar.style.display = 'none';
-        win.classList.remove('destroy');
-        win.style.visibility = 'hidden';
-        setTimeout(() => {
-          win.style.visibility = 'visible';
-          win.classList.add('fade-in');
-          setTimeout(() => win.classList.remove('fade-in'), 1000);
-        }, 2000);
-      };
+      closeBtn?.addEventListener("click", () => {
+        win.style.display = "none";
+        const next = win.parentElement.nextElementSibling;
+        if (next) next.scrollIntoView({ behavior: "smooth" });
+      });
 
-      win.addEventListener('mouseenter', showBar);
-
-      const destroyWindow = () => {
-        win.classList.add('destroy');
-        setTimeout(reset, 500);
-      };
-
-      closeBtn?.addEventListener('click', destroyWindow);
-      minBtn?.addEventListener('click', destroyWindow);
+      minBtn?.addEventListener("click", () => {
+        win.style.display = "none";
+        const icon = document.createElement("span");
+        icon.className = "window-icon";
+        icon.textContent =
+          win.querySelector(".title")?.textContent?.charAt(0) || "?";
+        icon.title = win.querySelector(".title")?.textContent || "";
+        icon.addEventListener("click", () => {
+          win.style.display = "block";
+          icon.remove();
+          win.scrollIntoView({ behavior: "smooth" });
+        });
+        tray.appendChild(icon);
+      });
     });
   }, []);
 


### PR DESCRIPTION
## Summary
- Invert parallax colors with theme and keep effects behind footer
- Add minimize, maximize and close controls with labels on home windows
- Implement window minimize tray and scroll-next behavior on close

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d58efdcc832fbfb84c1977b02c35